### PR TITLE
Load map thumbnails lazily

### DIFF
--- a/templates/maps.html
+++ b/templates/maps.html
@@ -24,7 +24,7 @@
          }
          .map-card {
          display: flex;
-         flex-direction: row; 
+         flex-direction: row;
          align-items: stretch; /* Make children take full height */
          padding: 0.3rem;
          border: 2px solid #ffbe2c;

--- a/templates/maps.html
+++ b/templates/maps.html
@@ -112,7 +112,7 @@
                   <a class="map-link" href="maps/{{ map.name }}">
                      {% endif %}
                      <button class="map-card">
-					    <img class="map-thumbnail" src="{{ url_for('static', filename=map.img_path) }}" alt="Map Thumbnail">
+					    <img class="map-thumbnail" src="{{ url_for('static', filename=map.img_path) }}" alt="Map Thumbnail" loading="lazy">
                         <div class="map-text">
                            <div>
                               <div class="map-name-and-author">


### PR DESCRIPTION
See individual commits for precise details, but basically: don't cause first-time navigators (uncached) to have a bad experience watching it load for over 10 seconds.