### PR TITLE
Fix/center header text

### DIFF
--- a/static/css/stylesheet.css
+++ b/static/css/stylesheet.css
@@ -20,7 +20,7 @@
 }
 
 .titleContainer {
-    width: 100%;
+    width: 100vw;
     height: 100%;
 }
 
@@ -109,12 +109,13 @@
     font-family: Montserrat;
     color: white;
     text-shadow: 0 0 5px #111;
-    width: 100%;
+    width: 100vw;
     bottom: 50%;
     z-index: 1;
 }
 
 .discordTop {
+    width: 100vw;
     position: relative;
     display: flex;
     grid-column-gap: 2vh;
@@ -123,6 +124,7 @@
 }
 
 .discordBottom {
+    width: 100vw;
     position: relative;
     display: flex;
     grid-column-gap: 2vh;
@@ -215,8 +217,6 @@ header {
     height: 80%;
     transform-style: preserve-3d;
     z-index: -1;
-    margin-left: calc(100vw - 100%);
-    margin-right: 0;
 }
 
 header:before {

--- a/static/css/stylesheet.css
+++ b/static/css/stylesheet.css
@@ -215,6 +215,8 @@ header {
     height: 80%;
     transform-style: preserve-3d;
     z-index: -1;
+    margin-left: calc(100vw - 100%);
+    margin-right: 0;
 }
 
 header:before {


### PR DESCRIPTION
I adjusted the width of the elements in the header to center them properly when a scrollbar is present. This way, the topbar image is aligned with them.

![passtime website fix](https://github.com/user-attachments/assets/3bbf846a-f92d-49bf-8b3b-4e826d141c6d)

Closes #4 